### PR TITLE
Adding time based checkpoints, and retries

### DIFF
--- a/image
+++ b/image
@@ -1,1 +1,1 @@
-scylladb/hydra-loaders:kcl-jdk8-20201229
+scylladb/hydra-loaders:kcl-jdk8-20210215


### PR DESCRIPTION
While trying to investigate scylladb/scylla#8012,
I've noticed we are not checkpointing at all,
so part of trying to pinpoint the issue I've update the code
based on the example from `aws-sdk-java` to include:

* time based checkpoints (once in a minute)
* retrying with backoffs on failures to checkpoint

Ref: https://github.com/aws/aws-sdk-java/blob/master/src/samples/AmazonKinesis/AmazonKinesisApplicationSampleRecordProcessor.java
Ref: https://github.com/scylladb/scylla/issues/8012